### PR TITLE
Add simple Flask web interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,14 @@ python main.py --prompt "A peaceful piano melody with soft strings"
 python main.py --output my_music.wav
 ```
 
+### 启动Web界面
+
+```bash
+# 在项目根目录
+python web_app.py
+# 浏览器访问 http://localhost:8000
+```
+
 ### 高级选项
 
 ```bash

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,5 @@ torch>=2.0.0
 transformers>=4.30.0
 scipy>=1.10.0
 accelerate>=0.20.0
-numpy>=1.21.0 
+numpy>=1.21.0
+Flask>=2.0

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="zh">
+<head>
+    <meta charset="utf-8">
+    <title>AI音乐生成器</title>
+</head>
+<body>
+    <h1>AI音乐生成器</h1>
+    <form action="/generate" method="post">
+        <label>提示词:</label><br>
+        <input type="text" name="prompt" size="60" value="A calming piano melody with gentle rain in the background"><br>
+        <label>模型:</label>
+        <select name="model">
+            <option value="small">small</option>
+            <option value="medium">medium</option>
+        </select><br>
+        <label>最大token数 (可选):</label>
+        <input type="number" name="max_tokens"><br>
+        <button type="submit">生成音乐</button>
+    </form>
+</body>
+</html>

--- a/templates/result.html
+++ b/templates/result.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<html lang="zh">
+<head>
+    <meta charset="utf-8">
+    <title>生成结果</title>
+</head>
+<body>
+    <h1>生成结果</h1>
+    <p>文件已生成: {{ filename }}</p>
+    <audio controls>
+        <source src="{{ url_for('static', filename=filename) }}" type="audio/wav">
+        您的浏览器不支持音频播放。
+    </audio>
+    <br>
+    <a href="{{ url_for('static', filename=filename) }}" download>下载</a>
+    <br>
+    <a href="{{ url_for('index') }}">再生成一个</a>
+</body>
+</html>

--- a/web_app.py
+++ b/web_app.py
@@ -1,0 +1,43 @@
+from pathlib import Path
+from flask import Flask, render_template, request, url_for
+
+from src.models.musicgen import MusicGen
+from src.utils.device import get_optimal_device
+
+app = Flask(__name__)
+
+STATIC_DIR = Path(__file__).parent / "static"
+STATIC_DIR.mkdir(exist_ok=True)
+
+# 创建MusicGen实例和设备
+DEVICE, DEVICE_NAME = get_optimal_device()
+print(f"使用设备: {DEVICE_NAME}")
+GENERATOR = MusicGen(model_size="small", device=DEVICE)
+
+@app.route("/")
+def index():
+    return render_template("index.html")
+
+@app.route("/generate", methods=["POST"])
+def generate():
+    prompt = request.form.get("prompt", "")
+    model = request.form.get("model", "small")
+    max_tokens = request.form.get("max_tokens")
+    try:
+        max_tokens = int(max_tokens) if max_tokens else None
+    except ValueError:
+        max_tokens = None
+
+    # 如果模型大小改变，重新创建生成器
+    global GENERATOR
+    if GENERATOR.model_size != model:
+        GENERATOR = MusicGen(model_size=model, device=DEVICE)
+
+    output_path = STATIC_DIR / f"generated_{model}.wav"
+    filename = GENERATOR.generate(prompt, max_tokens=max_tokens, output_path=str(output_path))
+    # 将文件名相对于static目录返回
+    rel_name = Path(filename).name
+    return render_template("result.html", filename=rel_name)
+
+if __name__ == "__main__":
+    app.run(host="0.0.0.0", port=8000)


### PR DESCRIPTION
## Summary
- add `web_app.py` with Flask routes to generate music
- create HTML templates for the interface
- track an empty `static` directory
- document web usage in README
- include Flask in requirements

## Testing
- `python -m compileall -q web_app.py src`

------
https://chatgpt.com/codex/tasks/task_e_687507506dc88324bf07c4f2818d2a20