### PR TITLE
Add simple Flask web interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,24 @@ python main.py --model medium --prompt "A smooth jazz piece with saxophone, pian
 python main.py --help
 ```
 
+### Web界面
+
+项目还提供了简单的Flask Web界面，运行以下命令启动：
+
+```bash
+python webapp.py
+```
+
+默认监听5000端口，可通过`--port`参数或`PORT`环境变量指定其他端口：
+
+```bash
+python webapp.py --port 8000
+# 或
+PORT=8000 python webapp.py
+```
+
+然后在浏览器中访问 `http://localhost:<端口>`。
+
 ## 📚 代码说明
 
 ### 文件作用详解

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,5 @@ torch>=2.0.0
 transformers>=4.30.0
 scipy>=1.10.0
 accelerate>=0.20.0
-numpy>=1.21.0 
+numpy>=1.21.0
+Flask>=2.3

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="zh">
+<head>
+    <meta charset="UTF-8">
+    <title>AI音乐生成器</title>
+    <style>
+        body { font-family: Arial, sans-serif; margin: 40px; }
+        label { display: block; margin-top: 10px; }
+        input[type="text"], input[type="number"] { width: 100%; padding: 8px; }
+        button { margin-top: 20px; padding: 10px 20px; }
+    </style>
+</head>
+<body>
+    <h1>AI音乐生成器</h1>
+    <form method="post">
+        <label for="prompt">提示词 (Prompt)</label>
+        <input id="prompt" type="text" name="prompt" value="{{ request.form.get('prompt', '') }}" required>
+
+        <label for="model">模型选择</label>
+        <select id="model" name="model">
+            <option value="small" {% if request.form.get('model') == 'small' %}selected{% endif %}>Small</option>
+            <option value="medium" {% if request.form.get('model') == 'medium' %}selected{% endif %}>Medium</option>
+        </select>
+
+        <label for="max_tokens">最大token数 (可选)</label>
+        <input id="max_tokens" type="number" name="max_tokens" value="{{ request.form.get('max_tokens', '') }}">
+
+        <button type="submit">生成音乐</button>
+    </form>
+
+    {% if audio_file %}
+    <h2>生成结果</h2>
+    <audio controls>
+        <source src="{{ url_for('static', filename=audio_file) }}" type="audio/wav">
+        您的浏览器不支持音频播放。
+    </audio>
+    <p><a href="{{ url_for('static', filename=audio_file) }}" download>下载音乐</a></p>
+    {% endif %}
+</body>
+</html>

--- a/webapp.py
+++ b/webapp.py
@@ -45,5 +45,23 @@ def index():
 
 
 if __name__ == '__main__':
-    app.run(host='0.0.0.0', port=5000, debug=True)
+    import argparse
+
+    parser = argparse.ArgumentParser(description='AI音乐生成Web服务')
+    parser.add_argument(
+        '--port',
+        type=int,
+        default=int(os.environ.get('PORT', 5000)),
+        help='服务端口，默认5000，可通过环境变量PORT或此参数指定'
+    )
+    parser.add_argument(
+        '--debug',
+        action='store_true',
+        default=os.environ.get('FLASK_DEBUG') == '1',
+        help='开启调试模式'
+    )
+
+    args = parser.parse_args()
+
+    app.run(host='0.0.0.0', port=args.port, debug=args.debug)
 

--- a/webapp.py
+++ b/webapp.py
@@ -1,0 +1,49 @@
+from flask import Flask, render_template, request
+import os
+import time
+
+from src.models.musicgen import MusicGen
+from src.utils.device import get_optimal_device
+
+app = Flask(__name__)
+
+# 缓存不同模型的生成器，避免重复加载
+_generators = {}
+
+
+def get_generator(model_size: str) -> MusicGen:
+    if model_size not in _generators:
+        device, _ = get_optimal_device()
+        _generators[model_size] = MusicGen(model_size=model_size, device=device)
+    return _generators[model_size]
+
+
+@app.route('/', methods=['GET', 'POST'])
+def index():
+    audio_file = None
+    if request.method == 'POST':
+        prompt = request.form.get('prompt', '')
+        model_size = request.form.get('model', 'small')
+        max_tokens = request.form.get('max_tokens')
+        max_tokens = int(max_tokens) if max_tokens else None
+
+        generator = get_generator(model_size)
+
+        # 在static目录下保存生成的音频
+        filename = f"music_{model_size}_{int(time.time())}.wav"
+        output_path = os.path.join('static', filename)
+
+        generator.generate(
+            prompt=prompt,
+            max_tokens=max_tokens,
+            output_path=output_path
+        )
+
+        audio_file = filename
+
+    return render_template('index.html', audio_file=audio_file)
+
+
+if __name__ == '__main__':
+    app.run(host='0.0.0.0', port=5000, debug=True)
+


### PR DESCRIPTION
## Summary
- create a minimal Flask web app `webapp.py`
- add HTML template `templates/index.html`
- store generated audio under `static`
- update requirements with Flask dependency

## Testing
- `python -m py_compile webapp.py`
- `find . -name '*.py' -print0 | xargs -0 python -m py_compile`

------
https://chatgpt.com/codex/tasks/task_e_687507506dc88324bf07c4f2818d2a20